### PR TITLE
Feat/send alert mail

### DIFF
--- a/apps/subscriptions/tasks.py
+++ b/apps/subscriptions/tasks.py
@@ -54,21 +54,30 @@ def _with_retry(fn, *args, **kwargs):
 # ---------------------------------------------------------------------------
 
 
+ALERT_RECIPIENTS = [
+    "chilfox@csie.ntu.edu.tw",
+    "qwertypig@csie.ntu.edu.tw",
+    "bbwinner@csie.ntu.edu.tw",
+]
+
+
 def _connect() -> Connection:
     server = Server(LDAP_URI, connect_timeout=10)
-    if not server:
-        send_alert_email(
-            recipients=["chilfox@csie.ntu.edu.tw", "qwertypig@csie.ntu.edu.tw", "bbwinner@csie.ntu.edu.tw"],
-            subject="LDAP Connection Failure",
-            body=f"Failed to initialize LDAP server object for URI: {LDAP_URI}",
+    try:
+        conn = Connection(
+            server,
+            user=LDAP_BIND_DN,
+            password=LDAP_BIND_PASSWORD,
+            auto_bind=True,
+            raise_exceptions=True,
         )
-    conn = Connection(
-        server,
-        user=LDAP_BIND_DN,
-        password=LDAP_BIND_PASSWORD,
-        auto_bind=True,
-        raise_exceptions=True,
-    )
+    except LDAPException as exc:
+        send_alert_email(
+            recipients=ALERT_RECIPIENTS,
+            subject="LDAP Connection Failure",
+            body=f"Failed to connect to LDAP server at {LDAP_URI}.\n\nError: {exc}",
+        )
+        raise
     return conn
 
 

--- a/apps/subscriptions/tasks.py
+++ b/apps/subscriptions/tasks.py
@@ -6,6 +6,8 @@ from django.core.cache import cache
 from ldap3 import LEVEL, MODIFY_ADD, MODIFY_DELETE, Connection, Server
 from ldap3.core.exceptions import LDAPEntryAlreadyExistsResult, LDAPException
 
+from core.mail import send_alert_email
+
 from .models import Alias, AliasTaskQueue, UserTaskQueue
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,12 @@ def _with_retry(fn, *args, **kwargs):
 
 def _connect() -> Connection:
     server = Server(LDAP_URI, connect_timeout=10)
+    if not server:
+        send_alert_email(
+            recipients=["chilfox@csie.ntu.edu.tw", "qwertypig@csie.ntu.edu.tw", "bbwinner@csie.ntu.edu.tw"],
+            subject="LDAP Connection Failure",
+            body=f"Failed to initialize LDAP server object for URI: {LDAP_URI}",
+        )
     conn = Connection(
         server,
         user=LDAP_BIND_DN,
@@ -121,6 +129,7 @@ def flush_alias_tasks(conn: Connection) -> None:
                 exc,
             )
 
+
 def flush_user_tasks(conn: Connection) -> None:
     """Process all rows in UserTaskQueue in id order."""
     for task in UserTaskQueue.objects.all():
@@ -144,6 +153,7 @@ def flush_user_tasks(conn: Connection) -> None:
                 task.alias_name,
                 exc,
             )
+
 
 def run_consistency_check(conn: Connection) -> None:
     """Pull ou=Aliases from LDAP and sync into the Alias cache (DB).

--- a/apps/subscriptions/tests.py
+++ b/apps/subscriptions/tests.py
@@ -312,3 +312,26 @@ class UserSubscriptionUpdateApiTest(TestCase):
 
         self.assertEqual(first.status_code, 202)
         self.assertEqual(second.status_code, 429)
+
+class ConnectAlertTest(TestCase):
+    @patch("apps.subscriptions.tasks.send_alert_email")
+    @patch("apps.subscriptions.tasks.Connection")
+    def test_sends_alert_on_ldap_connection_failure(self, mock_conn_cls, mock_alert):
+        mock_conn_cls.side_effect = LDAPException("connection refused")
+
+        from apps.subscriptions.tasks import _connect
+        with self.assertRaises(LDAPException):
+            _connect()
+
+        mock_alert.assert_called_once()
+        call_kwargs = mock_alert.call_args[1]
+        self.assertEqual(call_kwargs["subject"], "LDAP Connection Failure")
+        self.assertIn("chilfox@csie.ntu.edu.tw", call_kwargs["recipients"])
+
+    @patch("apps.subscriptions.tasks.send_alert_email")
+    @patch("apps.subscriptions.tasks.Connection")
+    def test_no_alert_on_successful_connection(self, mock_conn_cls, mock_alert):
+        # 正常連線不該寄信
+        from apps.subscriptions.tasks import _connect
+        _connect()
+        mock_alert.assert_not_called()

--- a/core/mail.py
+++ b/core/mail.py
@@ -1,0 +1,44 @@
+import logging
+import os
+import smtplib
+from email.message import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+SMTP_HOST = os.environ.get("SMTP_HOST", "localhost")
+SMTP_PORT = int(os.environ.get("SMTP_PORT", "25"))
+ALERT_SENDER = os.environ.get("ALERT_EMAIL_SENDER", "mailsub-alert@csie.ntu.edu.tw")
+
+
+def send_alert_email(recipients: list[str], body: str, subject: str = "System Alert") -> None:
+    """Send a plain-text alert email to a list of recipients via raw SMTP.
+
+    This function is intentionally fire-and-forget: errors are logged but never
+    raised, so a mail failure never masks the original exception that triggered
+    the alert.
+
+    Args:
+        recipients: List of recipient email addresses.
+        body: Plain-text email body.
+        subject: Email subject line (default: "System Alert").
+    """
+    if not recipients:
+        logger.warning("send_alert_email: recipients list is empty, skipping")
+        return
+
+    msg = EmailMessage()
+    msg["From"] = ALERT_SENDER
+    msg["To"] = ", ".join(recipients)
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    try:
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as smtp:
+            smtp.sendmail(ALERT_SENDER, recipients, msg.as_string())
+        logger.info(
+            "send_alert_email: sent '%s' to %s", subject, recipients
+        )
+    except Exception:
+        logger.exception(
+            "send_alert_email: failed to send '%s' to %s", subject, recipients
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       - LDAP_URI=${LDAP_URI:-ldap://localhost:389}
       - LDAP_BIND_DN=${LDAP_BIND_DN:-uid=mailtest,ou=people,dc=csie,dc=ntu,dc=edu,dc=tw}
       - LDAP_BIND_PASSWORD=${LDAP_BIND_PASSWORD:-}
+      - SMTP_HOST=${SMTP_HOST:-localhost}
+      - SMTP_PORT=${SMTP_PORT:-25}
+      - ALERT_EMAIL_SENDER=${ALERT_EMAIL_SENDER:-mailsub-alert@csie.ntu.edu.tw}
     depends_on:
       - postgres
       - redis
@@ -67,6 +70,9 @@ services:
       - LDAP_URI=${LDAP_URI:-ldap://localhost:389}
       - LDAP_BIND_DN=${LDAP_BIND_DN:-uid=mailtest,ou=people,dc=csie,dc=ntu,dc=edu,dc=tw}
       - LDAP_BIND_PASSWORD=${LDAP_BIND_PASSWORD:-}
+      - SMTP_HOST=${SMTP_HOST:-localhost}
+      - SMTP_PORT=${SMTP_PORT:-25}
+      - ALERT_EMAIL_SENDER=${ALERT_EMAIL_SENDER:-mailsub-alert@csie.ntu.edu.tw}
     depends_on:
       - postgres
       - redis

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,6 +14,9 @@
 | `REDIS_QUEUE_URL` | `redis://redis:6379/0` | Django-Q task queue |
 | `REDIS_CACHE_URL` | `redis://redis:6379/1` | Rate limit TTL cache |
 | `LDAP_URI` | `ldap://172.16.127.109:389` | LDAP server |
+| `SMTP_HOST` | `localhost` | Alert email 用的 SMTP server |
+| `SMTP_PORT` | `25` | SMTP port（Mailpit 用 `1025`）|
+| `ALERT_EMAIL_SENDER` | `mailsub-alert@csie.ntu.edu.tw` | Alert email 寄件人 |
 
 > [!warning] Redis index 分開
 > index 0（queue）與 index 1（cache）刻意分開，避免 task queue 的 key 被 cache 操作誤刪。

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -66,6 +66,16 @@ Flush 完成、`user_task_queue` 清空後，立即執行一次 consistency chec
 
 ---
 
+## 錯誤通知（Alert Email）
+
+當 worker 無法連上 LDAP server 時（`_connect()` 拋出 `LDAPException`），系統會透過 SMTP 寄送 alert email 給管理者，再重新拋出例外讓 `flush_ldap_tasks()` 的錯誤處理正常運作。
+
+收件人定義在 `apps/subscriptions/tasks.py` 的 `ALERT_RECIPIENTS`。
+
+SMTP 設定由環境變數控制（見 [setup — 環境變數](./setup.md#環境變數)）。開發環境可搭配 Mailpit（`SMTP_PORT=1025`）攔截信件，不會實際寄出。
+
+---
+
 ## 兩個階段的關係
 
 Consistency Check 不是獨立排程，而是每次 Flush 的後半段：

--- a/progress/chilfox/testing-procedure.md
+++ b/progress/chilfox/testing-procedure.md
@@ -171,7 +171,7 @@ CSRF=$(grep csrftoken cookies.txt | awk '{print $NF}')
 curl -s -b cookies.txt -X PUT http://localhost:8000/api/v1/user/subscriptions/ \
   -H "Content-Type: application/json" \
   -H "X-CSRFToken: $CSRF" \
-  -d '{"test-list": true, "workstation": false}' | python3 -m json.tool
+  -d '{"test-list": true, "workstation": false, "sw-user": false}' | python3 -m json.tool
 ```
 
 **預期 202**：


### PR DESCRIPTION
Summary

- 新增 `core/mail.py`：`send_alert_email(recipients, body, subject)` 透過 SMTP 寄送 alert email，失敗只 log 不 raise，避免遮蓋原始錯誤
- `_connect()` 在 LDAP 連線失敗（`LDAPException`）時觸發 alert，寄信後重新拋出例外讓原有錯誤處理正常運作
- 新增 `ConnectAlertTest`：驗證連線失敗時 alert 被觸發、連線成功時不寄信
- `docker-compose.yml` 加入 `SMTP_HOST`、`SMTP_PORT`、`ALERT_EMAIL_SENDER` 環境變數（`web` 與 `worker` 兩個 container）
- 更新 `docs/setup.md` 環境變數表、`docs/sync.md` 新增錯誤通知段落